### PR TITLE
fix(empty): 修复auto-hide-empty-view-when-loading为false且列表不为空时, 加载中时列表底…

### DIFF
--- a/z-paging/uni_modules/z-paging/components/z-paging/js/modules/empty.js
+++ b/z-paging/uni_modules/z-paging/components/z-paging/js/modules/empty.js
@@ -112,14 +112,13 @@ export default {
 			return this.isLoadFailed ? this.showEmptyViewReloadWhenError : this.showEmptyViewReload;
 		},
 		showEmpty() {
-			if (this.refresherOnly || this.hideEmptyView || this.totalData.length) return false;
+			if (this.refresherOnly || this.hideEmptyView || this.realTotalData.length) return false;
 			if (this.autoHideEmptyViewWhenLoading) {
 				if (this.isAddedData && !this.firstPageLoaded && !this.loading) return true;
 			} else {
 				return true;
 			}
-			if (!this.autoHideEmptyViewWhenPull && !this.isUserReload) return true;
-			return false;
+			return !this.autoHideEmptyViewWhenPull && !this.isUserReload;
 		},
 	},
 	methods: {


### PR DESCRIPTION
修复auto-hide-empty-view-when-loading为false且列表不为空时, 加载中时列表底部仍然会出现空数据视图