### PR TITLE
fix: 默认配置读取空值判断错误

### DIFF
--- a/z-paging/components/z-paging/js/z-paging-utils.js
+++ b/z-paging/components/z-paging/js/z-paging-utils.js
@@ -12,7 +12,8 @@ const timeoutMap = {};
 function gc(key, defaultValue) {
 	_handleDefaultConfig();
 	if (!config) return defaultValue;
-	return config[key] || defaultValue;
+	const value = config[key];
+	return value === undefined ? defaultValue : value;
 }
 
 //获取最终的touch位置
@@ -39,8 +40,8 @@ function getTouchFromZPaging(target) {
 		const classList = target.classList;
 		if (classList && classList.contains('z-paging-content')) {
 			return {
-				isFromZp: true, 
-				isPageScroll: classList.contains('z-paging-content-page'), 
+				isFromZp: true,
+				isPageScroll: classList.contains('z-paging-content-page'),
 				isReachedTop: classList.contains('z-paging-reached-top')
 			};
 		} else {


### PR DESCRIPTION
当默认配置项为false或者0时，gc()返回了defaultValue。