### PR TITLE
feat: 新增ZPagingResolver用于unplugin-vue-components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .DS_Store
 build/*
 !build/icons
@@ -6,4 +7,5 @@ npm-debug.log.*
 yarn.lock
 thumbs.db
 !.gitkeep
+node_modules
 /**/unpackage/*

--- a/z-paging/package.json
+++ b/z-paging/package.json
@@ -10,7 +10,7 @@
     "分页器",
     "nvue",
     "虚拟列表"
-],
+  ],
   "repository": "https://github.com/SmileZXLee/uni-z-paging",
   "types": "global.d.ts",
   "engines": {
@@ -84,5 +84,8 @@
         }
       }
     }
+  },
+  "devDependencies": {
+    "unplugin-vue-components": "^0.27.0"
   }
 }

--- a/z-paging/resolver/index.d.ts
+++ b/z-paging/resolver/index.d.ts
@@ -1,0 +1,9 @@
+import type { ComponentResolver } from "unplugin-vue-components";
+
+export interface ZPagingResolverOptions {
+  exclude?: RegExp;
+}
+
+export function ZPagingResolver(options?: ZPagingResolverOptions): ComponentResolver;
+
+export {};

--- a/z-paging/resolver/index.mjs
+++ b/z-paging/resolver/index.mjs
@@ -1,0 +1,27 @@
+function kebabCase(key) {
+  return key.replace(/([A-Z])/g, " $1")
+    .trim()
+    .split(" ")
+    .join("-")
+    .toLowerCase();
+}
+
+export function ZPagingResolver(options = {}) {
+  return {
+    type: "component",
+    resolve: (name) => {
+      if (options.exclude && name.match(options.exclude)) {
+        return undefined;
+      }
+
+      const kebabCaseName = kebabCase(name);
+
+      if (/^(?!z-paging-refresh|z-paging-load-more)z-paging(.*)/.test(kebabCaseName)) {
+        return {
+          name: kebabCaseName,
+          from: `z-paging/components/${kebabCaseName}/${kebabCaseName}.vue`
+        };
+      }
+    }
+  };
+}


### PR DESCRIPTION
1. 安装依赖

```shell
npm i -D @uni-helper/vite-plugin-uni-components
```

2. 配置Resolver

```typescript
// vite.config.ts

import UniApp from "@dcloudio/vite-plugin-uni";
import UniHelperComponents from "@uni-helper/vite-plugin-uni-components";
import { defineConfig } from "vite";
import { ZPagingResolver } from "z-paging/resolver";

export default defineConfig({
  plugins: [
    // ...
    UniHelperComponents({
      // ...
      // 在这里添加ZPagingResolver
      resolvers: [ZPagingResolver()]
    }),
    // uniapp插件写到最后
    UniApp()
  ]
});
```

【注意】`easycom` 和 `unplguin` 两种自动导入组件的方式任选其一即可，不要同时使用

```json5
// pages.json

{
  "easycom": {
    "custom": {
      // ...
      // 如果使用unplguin方式的话，去掉下面这行
      // "^(?!z-paging-refresh|z-paging-load-more)z-paging(.*)": "z-paging/components/z-paging$1/z-paging$1.vue"
    }
  }
}
```