### PR TITLE
fix:修复ios下waterfall宽度获取异常的问题

### DIFF
--- a/demo/z-paging-demo/uni_modules/z-paging/components/z-paging/js/modules/nvue.js
+++ b/demo/z-paging-demo/uni_modules/z-paging/components/z-paging/js/modules/nvue.js
@@ -96,6 +96,19 @@ export default {
 		nWaterfallRightGap() {
 			return this._nGetWaterfallConfig('right-gap', 0);
 		},
+		nWaterfallWidth() {
+			return this._nGetWaterfallConfig('water-width', 0);
+		},
+		nWaterfallHeight() {
+			return this._nGetWaterfallConfig('water-height', 0);
+		},
+		nWaterfallSizeStyle(){
+			const waterfallWidth = this.nWaterfallWidth;
+			const waterfallHeight = this.nWaterfallHeight;
+			if (waterfallWidth!== 0 && waterfallHeight !== 0) {
+				return{'width':waterfallWidth,'height':waterfallHeight}
+			}
+		},
 		nViewIs() {
 			const is = this.finalNvueListIs;
 			return is === 'scroller' || is === 'view' ? 'view' : is === 'waterfall' ? 'header' : 'cell';

--- a/z-paging/components/z-paging/z-paging.vue
+++ b/z-paging/components/z-paging/z-paging.vue
@@ -201,7 +201,7 @@ v2.8.6 (2025-03-17)
 			<view v-if="zSlots.left" class="zp-page-left">
 				<slot name="left" />
 			</view>
-			<component :is="finalNvueListIs" ref="zp-n-list" :id="nvueListId" :style="[{'flex': 1,'top':isIos?'0px':'-1px'},usePageScroll?scrollViewStyle:{},chatRecordRotateStyle]" :alwaysScrollableVertical="true"
+			<component :is="finalNvueListIs" ref="zp-n-list" :id="nvueListId" :style="[{'flex': 1,'top':isIos?'0px':'-1px'},usePageScroll?scrollViewStyle:{},chatRecordRotateStyle,nWaterfallSizeStyle]" :alwaysScrollableVertical="true"
 				:fixFreezing="nFixFreezing" :show-scrollbar="showScrollbar" :loadmoreoffset="finalLowerThreshold" :enable-back-to-top="enableBackToTop"
 				:scrollable="finalScrollable" :bounce="nvueBounce" :column-count="nWaterfallColumnCount" :column-width="nWaterfallColumnWidth"
 				:column-gap="nWaterfallColumnGap" :left-gap="nWaterfallLeftGap" :right-gap="nWaterfallRightGap" :pagingEnabled="nvuePagingEnabled" :offset-accuracy="offsetAccuracy"


### PR DESCRIPTION
创建了两个新的waterfall可传参数 (water-width,water-height)  可以改变waterfall的宽高 实现小尺寸的样式
![C7B080A0-9802-4A85-B3D2-1C56ABA49955](https://github.com/user-attachments/assets/c4f1d2a2-dea5-4155-a445-5499fc5044ea)
ps:如图左边是一个list右边是一个制定宽高三列的waterfall